### PR TITLE
Adjust connection icon color to be more visible

### DIFF
--- a/files/www/css/style.css
+++ b/files/www/css/style.css
@@ -333,7 +333,7 @@ header button.wifi-error {
 }
 
 #status_icon.waiting {
-	color: #efefef;
+	color: #c6c6c6;
 }
 
 #status_icon.connecting {
@@ -341,7 +341,7 @@ header button.wifi-error {
 }
 
 #status_icon.connected {
-	color: #182ac3;
+	color: #fff;
 }
 
 #status_icon.tunneled {
@@ -349,7 +349,7 @@ header button.wifi-error {
 }
 
 #status_icon.disconnected {
-	color: #c6c6c6;
+	color: #a6a6a6;
 }
 
 #status_icon.error {


### PR DESCRIPTION
Currently the »Connected« icon (which ideally you see most of the time) looks like this:
![screenshot from 2017-07-16 16-38-00](https://user-images.githubusercontent.com/925062/28248465-54365370-6a45-11e7-85f3-f68cb6830bd9.png)
A bit strange and too little contrast.

So instead I changed it to be white, as the normal/expected state doesn’t need a special color:
![screenshot from 2017-07-16 16-38-31](https://user-images.githubusercontent.com/925062/28248471-5d8dfa0e-6a45-11e7-98b8-5c372afc85b7.png)
To prevent confusion with the color of »Waiting« and »Disconnected«, I darkened both of those a bit.

What do you think @bnvk @JulianOliver?
