### PR TITLE
Prevent wrapping of 'Wi-Fi' button text in header

### DIFF
--- a/files/www/css/style.css
+++ b/files/www/css/style.css
@@ -264,6 +264,7 @@ header form button {
 	font-size: 14px;
 	font-weight: normal;
 	color: #111;
+	white-space: nowrap;
 }
 
 header form button:hover {


### PR DESCRIPTION
On my small phone screen it wrapped the label of the Wi-Fi icon:
![screenshot from 2017-07-16 16-42-04](https://user-images.githubusercontent.com/925062/28248510-cb8ced9e-6a45-11e7-9130-994c615dd516.png)

Fixed:
![screenshot from 2017-07-16 16-42-27](https://user-images.githubusercontent.com/925062/28248509-cb6bd974-6a45-11e7-856d-2a60eadcfc9a.png)

cc @JulianOliver @bnvk :)