### PR TITLE
Prevent wrong text wrapping in footer

### DIFF
--- a/files/www/css/style.css
+++ b/files/www/css/style.css
@@ -385,6 +385,7 @@ footer ul li {
 	margin: 0 1em;
 	font-size: 14px;
 	color: #a3a3a3;
+	white-space: nowrap;
 }
 
 footer img.little-snipper {


### PR DESCRIPTION
Footer before with strange wrapping after »ID:«
![screenshot from 2017-07-16 16-45-59](https://user-images.githubusercontent.com/925062/28248544-886dbcd6-6a46-11e7-97df-846119d3155e.png)

Fixed:
![screenshot from 2017-07-16 16-46-16](https://user-images.githubusercontent.com/925062/28248543-886d2d66-6a46-11e7-8e81-e73b17dffba0.png)
